### PR TITLE
Properly use the right overlay based on engagement mode.

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -101,7 +101,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.only(left: 10.0),
                   child: Text(
-                    "To which meal?",
+                    "To which meal? (Tap to select)",
                     style: TextStyle(color: Colors.grey, fontWeight: FontWeight.w500),
                   ),
                 ),
@@ -117,6 +117,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         selectedIndex1 = index;
                       });
                     },
+                    mode: DirectSelectMode.tap,
                     items: _buildItems1()),
                 Padding(
                   padding: const EdgeInsets.only(left: 10.0, top: 20.0),
@@ -161,7 +162,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.only(left: 10.0, top: 20.0),
                   child: Text(
-                    "Select your goal",
+                    "Select your goal (Tap to select)",
                     style: TextStyle(color: Colors.grey, fontWeight: FontWeight.w500),
                   ),
                 ),

--- a/lib/direct_select.dart
+++ b/lib/direct_select.dart
@@ -3,7 +3,10 @@ library direct_select_plugin;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+part 'src/base.dart';
 part 'src/enum.dart';
 part 'src/overlay.dart';
 part 'src/scroll_controller.dart';
 part 'src/widget.dart';
+part 'src/widget_drag.dart';
+part 'src/widget_tap.dart';

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -1,0 +1,133 @@
+part of direct_select_plugin;
+
+abstract class _DirectSelectBase extends StatefulWidget {
+  /// See: [DirectSelect.child]
+  final Widget child;
+
+  /// See: [DirectSelect.items]
+  final List<Widget> items;
+
+  /// See: [DirectSelect.onSelectedItemChanged]
+  final ValueChanged<int> onSelectedItemChanged;
+
+  /// See: [DirectSelect.itemExtent]
+  final double itemExtent;
+
+  /// See: [DirectSelect.itemMagnification]
+  final double itemMagnification;
+
+  /// See: [DirectSelect.selectedIndex]
+  final int selectedIndex;
+
+  /// See: [DirectSelect.mode]
+  final DirectSelectMode mode;
+
+  /// See: [DirectSelect.backgroundColor]
+  final Color backgroundColor;
+
+  const _DirectSelectBase({
+    this.child,
+    this.items,
+    this.onSelectedItemChanged,
+    this.itemExtent,
+    this.itemMagnification,
+    this.selectedIndex,
+    this.mode,
+    this.backgroundColor,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  _DirectSelectBaseState createState();
+}
+
+abstract class _DirectSelectBaseState<T extends _DirectSelectBase> extends State<T> {
+  _FixedExtentScrollController _controller;
+  GlobalKey _key = GlobalKey();
+  int _currentIndex;
+
+  Future<void> _createOverlay();
+
+  Future<void> _removeOverlay();
+
+  @override
+  void initState() {
+    _currentIndex = widget.selectedIndex;
+    _controller = _FixedExtentScrollController(widget.selectedIndex);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(_DirectSelectBase oldWidget) {
+    if (widget.selectedIndex != oldWidget.selectedIndex) {
+      _currentIndex = widget.selectedIndex;
+      _controller.dispose();
+      _controller = _FixedExtentScrollController(widget.selectedIndex);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _notifySelectedItem() {
+    widget.onSelectedItemChanged(_currentIndex);
+  }
+
+  Widget _overlayWidget([Key key]) {
+    final RenderBox box = _key.currentContext.findRenderObject();
+    final position = box.localToGlobal(Offset.zero);
+    final mediaQuery = MediaQuery.of(context);
+    final half = mediaQuery.size.height / 2;
+    final result = position.dy - mediaQuery.padding.top - half;
+    return _MySelectionOverlay(
+      key: key,
+      top: result + widget.itemExtent * widget.itemMagnification,
+      backgroundColor: widget.backgroundColor,
+      child: _MySelectionList(
+        itemExtent: widget.itemExtent,
+        itemMagnification: widget.itemMagnification,
+        childCount: widget.items != null ? widget.items.length : 0,
+        onItemChanged: (index) {
+          if (index != null) {
+            _currentIndex = index;
+          }
+        },
+        onItemSelected: () {
+          if (widget.mode == DirectSelectMode.tap) {
+            _removeOverlay();
+          }
+        },
+        builder: (context, index) {
+          if (widget.items != null) {
+            return widget.items[index];
+          }
+          return const SizedBox.shrink();
+        },
+        controller: _controller,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final preferTapMode = widget.mode == DirectSelectMode.tap;
+    return GestureDetector(
+      onTap: preferTapMode ? _createOverlay : null,
+      onVerticalDragStart: preferTapMode ? null : (_) => _createOverlay(),
+      onVerticalDragEnd: preferTapMode ? null : (_) => _removeOverlay(),
+      onVerticalDragUpdate: preferTapMode
+          ? null
+          : (details) => _controller.hasScrollPositions
+              ? _controller.jumpTo(_controller.offset - details.primaryDelta)
+              : null,
+      child: Container(
+        key: _key,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/src/overlay.dart
+++ b/lib/src/overlay.dart
@@ -5,7 +5,6 @@ class _MySelectionOverlay extends StatefulWidget {
   final Widget child;
   final double bottom;
   final Color backgroundColor;
-  final Color textColor;
 
   const _MySelectionOverlay({
     Key key,
@@ -13,7 +12,6 @@ class _MySelectionOverlay extends StatefulWidget {
     this.bottom,
     this.child,
     this.backgroundColor,
-    this.textColor,
   }) : super(key: key);
 
   @override

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -64,7 +64,7 @@ class _DirectSelectState extends State<DirectSelect> {
         useRootNavigator: true,
         barrierDismissible: false,
         barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-        barrierColor: const Color(0x00FFFFFF),
+        barrierColor: null, // this ensures that the barrier would be transparent.
         transitionDuration: const Duration(milliseconds: 230),
         transitionBuilder: (buildContext, animation, secondaryAnimation, child) => FadeTransition(
           opacity: CurvedAnimation(

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -64,7 +64,7 @@ class _DirectSelectState extends State<DirectSelect> {
         useRootNavigator: true,
         barrierDismissible: false,
         barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-        barrierColor: Colors.transparent,
+        barrierColor: const Color(0x00FFFFFF),
         transitionDuration: const Duration(milliseconds: 230),
         transitionBuilder: (buildContext, animation, secondaryAnimation, child) => FadeTransition(
           opacity: CurvedAnimation(

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -1,6 +1,6 @@
 part of direct_select_plugin;
 
-class DirectSelect extends StatefulWidget {
+class DirectSelect extends StatelessWidget {
   /// Widget child you'll tap to display the Selection List.
   final Widget child;
 
@@ -26,148 +26,50 @@ class DirectSelect extends StatefulWidget {
   final Color backgroundColor;
 
   const DirectSelect({
-    Key key,
-    this.selectedIndex,
-    this.mode = DirectSelectMode.drag,
-    this.itemMagnification = 1.15,
-    @required this.child,
     @required this.items,
     @required this.onSelectedItemChanged,
     @required this.itemExtent,
+    @required this.child,
+    this.selectedIndex = 0,
+    this.mode = DirectSelectMode.drag,
+    this.itemMagnification = 1.15,
     this.backgroundColor = Colors.white,
-  })  : assert(child != null),
+    Key key,
+  })  : assert(items != null && items.length > 0),
         assert(onSelectedItemChanged != null),
         assert(itemExtent != null),
+        assert(child != null),
+        assert(selectedIndex != null && selectedIndex >= 0 && selectedIndex < items.length),
+        assert(mode != null),
+        assert(itemMagnification != null && itemMagnification >= 1.0),
         super(key: key);
 
   @override
-  _DirectSelectState createState() => _DirectSelectState();
-}
-
-class _DirectSelectState extends State<DirectSelect> {
-  _FixedExtentScrollController _controller;
-  GlobalKey _key = GlobalKey();
-  int _currentIndex;
-  bool _dialogShowing;
-
-  void _createOverlay() async {
-    if (mounted) {
-      final RenderBox box = _key.currentContext.findRenderObject();
-      final position = box.localToGlobal(Offset.zero);
-      final mediaQuery = MediaQuery.of(context);
-      final half = mediaQuery.size.height / 2;
-      final result = position.dy - mediaQuery.padding.top - half;
-      final itemExtent = widget.itemExtent;
-      _dialogShowing = true;
-      await showGeneralDialog(
-        context: context,
-        useRootNavigator: true,
-        barrierDismissible: false,
-        barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-        barrierColor: null, // this ensures that the barrier would be transparent.
-        transitionDuration: const Duration(milliseconds: 230),
-        transitionBuilder: (buildContext, animation, secondaryAnimation, child) => FadeTransition(
-          opacity: CurvedAnimation(
-            parent: animation,
-            curve: Curves.easeOut,
-          ),
-          child: child,
-        ),
-        pageBuilder: (context, animation, secondaryAnimation) => WillPopScope(
-          onWillPop: () async {
-            _dialogShowing = false;
-            _notifySelectedItem();
-            return true;
-          },
-          child: _MySelectionOverlay(
-            top: result + itemExtent * widget.itemMagnification,
-            backgroundColor: widget.backgroundColor,
-            child: _MySelectionList(
-              itemExtent: widget.itemExtent,
-              itemMagnification: widget.itemMagnification,
-              childCount: widget.items != null ? widget.items.length : 0,
-              onItemChanged: (index) {
-                if (index != null) {
-                  _currentIndex = index;
-                }
-              },
-              onItemSelected: () {
-                if (widget.mode == DirectSelectMode.tap) {
-                  _removeOverlay();
-                }
-              },
-              builder: (context, index) {
-                if (widget.items != null) {
-                  return widget.items[index];
-                }
-                return const SizedBox.shrink();
-              },
-              controller: _controller,
-            ),
-          ),
-        ),
-      );
-    }
-  }
-
-  void _notifySelectedItem() {
-    widget.onSelectedItemChanged(_currentIndex);
-  }
-
-  Future<void> _removeOverlay() async {
-    if (mounted) {
-      final navigator = Navigator.of(context);
-      if (_dialogShowing && navigator != null) {
-        if (!await navigator.maybePop()) {
-          _notifySelectedItem();
-        }
-      } else {
-        _notifySelectedItem();
-      }
-      _dialogShowing = false;
-    }
-  }
-
-  @override
-  void didUpdateWidget(DirectSelect oldWidget) {
-    if (widget.selectedIndex != oldWidget.selectedIndex) {
-      _currentIndex = widget.selectedIndex;
-      _controller.dispose();
-      _controller = _FixedExtentScrollController(widget.selectedIndex);
-    }
-    super.didUpdateWidget(oldWidget);
-  }
-
-  @override
-  void initState() {
-    _currentIndex = widget.selectedIndex ?? 0;
-    _controller = _FixedExtentScrollController(widget.selectedIndex);
-    _dialogShowing = false;
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final preferTapMode = widget.mode == DirectSelectMode.tap;
-    return GestureDetector(
-      onTap: preferTapMode ? _createOverlay : null,
-      onVerticalDragStart: preferTapMode ? null : (_) => _createOverlay(),
-      onVerticalDragEnd: preferTapMode ? null : (_) => _removeOverlay(),
-      onVerticalDragUpdate: preferTapMode
-          ? null
-          : (details) => _controller.hasScrollPositions
-              ? _controller.jumpTo(_controller.offset - details.primaryDelta)
-              : null,
-      child: Container(
-        key: _key,
-        child: widget.child,
-      ),
-    );
+    switch (mode) {
+      case DirectSelectMode.drag:
+        return _DirectSelectDrag(
+          selectedIndex: selectedIndex,
+          mode: mode,
+          itemMagnification: itemMagnification,
+          items: items,
+          onSelectedItemChanged: onSelectedItemChanged,
+          itemExtent: itemExtent,
+          backgroundColor: backgroundColor,
+          child: child,
+        );
+      case DirectSelectMode.tap:
+        return _DirectSelectTap(
+          selectedIndex: selectedIndex,
+          mode: mode,
+          itemMagnification: itemMagnification,
+          items: items,
+          onSelectedItemChanged: onSelectedItemChanged,
+          itemExtent: itemExtent,
+          backgroundColor: backgroundColor,
+          child: child,
+        );
+    }
+    throw UnimplementedError('Unknown DirectSelectMode provided: $mode');
   }
 }

--- a/lib/src/widget_drag.dart
+++ b/lib/src/widget_drag.dart
@@ -1,0 +1,61 @@
+part of direct_select_plugin;
+
+class _DirectSelectDrag extends _DirectSelectBase {
+  const _DirectSelectDrag({
+    Widget child,
+    List<Widget> items,
+    ValueChanged<int> onSelectedItemChanged,
+    double itemExtent,
+    double itemMagnification,
+    int selectedIndex,
+    DirectSelectMode mode,
+    Color backgroundColor,
+    Key key,
+  }) : super(
+          selectedIndex: selectedIndex,
+          mode: mode,
+          itemMagnification: itemMagnification,
+          items: items,
+          onSelectedItemChanged: onSelectedItemChanged,
+          itemExtent: itemExtent,
+          backgroundColor: backgroundColor,
+          child: child,
+          key: key,
+        );
+
+  @override
+  _DirectSelectDragState createState() => _DirectSelectDragState();
+}
+
+class _DirectSelectDragState extends _DirectSelectBaseState<_DirectSelectDrag> {
+  OverlayEntry _overlayEntry;
+  GlobalKey<_MySelectionOverlayState> _keyOverlay;
+
+  @override
+  Future<void> _createOverlay() async {
+    if (mounted) {
+      OverlayState overlayState = Overlay.of(context);
+      if (overlayState != null) {
+        _overlayEntry = OverlayEntry(builder: (_) => _overlayWidget(_keyOverlay));
+        overlayState.insert(_overlayEntry);
+      }
+    }
+  }
+
+  @override
+  Future<void> _removeOverlay() async {
+    if (mounted) {
+      final currentState = _keyOverlay.currentState;
+      if (currentState != null) {
+        currentState.reverse(_overlayEntry);
+      }
+      _notifySelectedItem();
+    }
+  }
+
+  @override
+  void initState() {
+    _keyOverlay = GlobalKey();
+    super.initState();
+  }
+}

--- a/lib/src/widget_tap.dart
+++ b/lib/src/widget_tap.dart
@@ -1,0 +1,83 @@
+part of direct_select_plugin;
+
+class _DirectSelectTap extends _DirectSelectBase {
+  const _DirectSelectTap({
+    Widget child,
+    List<Widget> items,
+    ValueChanged<int> onSelectedItemChanged,
+    double itemExtent,
+    double itemMagnification,
+    int selectedIndex,
+    DirectSelectMode mode,
+    Color backgroundColor,
+    Key key,
+  }) : super(
+          selectedIndex: selectedIndex,
+          mode: mode,
+          itemMagnification: itemMagnification,
+          items: items,
+          onSelectedItemChanged: onSelectedItemChanged,
+          itemExtent: itemExtent,
+          backgroundColor: backgroundColor,
+          child: child,
+          key: key,
+        );
+
+  @override
+  _DirectSelectTapState createState() => _DirectSelectTapState();
+}
+
+class _DirectSelectTapState extends _DirectSelectBaseState<_DirectSelectTap> {
+  bool _dialogShowing;
+
+  @override
+  Future<void> _createOverlay() async {
+    if (mounted) {
+      _dialogShowing = true;
+      await showGeneralDialog(
+        context: context,
+        useRootNavigator: true,
+        barrierDismissible: false,
+        barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+        barrierColor: null, // this ensures that the barrier would be transparent.
+        transitionDuration: const Duration(milliseconds: 230),
+        transitionBuilder: (buildContext, animation, secondaryAnimation, child) => FadeTransition(
+          opacity: CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOut,
+          ),
+          child: child,
+        ),
+        pageBuilder: (context, animation, secondaryAnimation) => WillPopScope(
+          onWillPop: () async {
+            _dialogShowing = false;
+            _notifySelectedItem();
+            return true;
+          },
+          child: _overlayWidget(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> _removeOverlay() async {
+    if (mounted) {
+      final navigator = Navigator.of(context);
+      if (_dialogShowing && navigator != null) {
+        if (!await navigator.maybePop()) {
+          _notifySelectedItem();
+        }
+      } else {
+        _notifySelectedItem();
+      }
+      _dialogShowing = false;
+    }
+  }
+
+  @override
+  void initState() {
+    _dialogShowing = false;
+    super.initState();
+  }
+}


### PR DESCRIPTION
Works on my end, doctor -v:

```
[✓] Flutter (Channel master, 1.22.0-10.0.pre.380, on Linux, locale en_US.utf8)
    • Flutter version 1.22.0-10.0.pre.380 at /home/noor/Google/Flutter
    • Framework revision ec40df9576 (2 days ago), 2020-09-25 21:27:22 -0700
    • Engine revision 3a73d073c8
    • Dart version 2.11.0 (build 2.11.0-161.0.dev)
```